### PR TITLE
Fix all warnings and other small improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1"
+lazy_static = "1"
 rodio = "0.11.0"
 rand = "0.7.3"
-regex = "1.3.9"
-lazy_static = "1.4.0"
 proptest = "0.10.0"
 
 [profile.release]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,29 @@
+#[macro_export]
+macro_rules! map {
+	() => ({
+		let temp_map = ::std::collections::HashMap::new();
+		temp_map
+	});
+	($($key:expr => $value:expr),+) => ({
+		let mut temp_map = ::std::collections::HashMap::new();
+		$(
+			temp_map.insert($key, $value);
+		)+
+		temp_map
+	});
+}
+
+#[macro_export]
+macro_rules! set {
+	() => ({
+		let temp_set = ::std::collections::HashSet::new();
+		temp_set
+	});
+	($($x:expr),+) => ({ // Match one or more comma delimited items
+		let mut temp_set = ::std::collections::HashSet::new();  // Create a mutable HashSet
+		$(
+			temp_set.insert($x); // Insert each item matched into the HashSet
+		)+
+		temp_set // Return the populated HashSet
+	});
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+mod macros;
+
 use std::fs::File;
 use std::io::BufReader;
 use std::collections::{HashSet, HashMap};
-use std::fs;
-use std::env;
+use std::{env, fs};
+use std::path::{Path, PathBuf};
 use rodio::Sink;
 use rodio::decoder::Decoder;
 use rodio::{source::Zero, Source};
@@ -19,30 +21,6 @@ lazy_static! {
 }
 
 // Do NOT use mp3.
-
-macro_rules! map(
-	{ $($key:expr => $value:expr),+ } => {
-		{
-			let mut m = ::std::collections::HashMap::new();
-			$(
-				m.insert($key, $value);
-			)+
-			m
-		}
-	 };
-);
-
-macro_rules! set {
-	( $( $x:expr ),* ) => {  // Match zero or more comma delimited items
-		{
-			let mut temp_set = HashSet::new();  // Create a mutable HashSet
-			$(
-				temp_set.insert($x); // Insert each item matched into the HashSet
-			)*
-			temp_set // Return the populated HashSet
-		}
-	};
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SongSegment {
@@ -61,7 +39,7 @@ pub struct Song {
 
 impl Song {
 	fn read_segment(&self, segment: &str) -> Decoder<BufReader<File>> {
-		let file = File::open(format!("songs/song_{}_{}.ogg", self.id.as_str(), segment)).unwrap();
+		let file = File::open(format!("songs/song_{}_{}.ogg", self.id, segment)).unwrap();
 		Decoder::new(BufReader::new(file)).unwrap()
 	}
 
@@ -97,13 +75,14 @@ impl Song {
 	}
 }
 
-pub fn initialize_songs(paths: &[String]) -> HashMap<String, Song> {
+pub fn initialize_songs<P: AsRef<Path>>(paths: &[P]) -> HashMap<String, Song> {
 	let mut songs = HashMap::new();
 	for path in paths {
-		let file_name = path.split('/').rev().next().unwrap().to_string();
-		let name_split = file_name.split('_').collect::<Vec<&str>>();
+		let path = path.as_ref();
+		let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+		let name_split = file_name.split('_').collect::<Vec<_>>();
 		let song_id = name_split[1].to_string();
-		let song_segment_id = name_split[2].to_string().split('.').collect::<Vec<&str>>()[0].to_string();
+		let song_segment_id = name_split[2].to_string().split('.').collect::<Vec<_>>()[0].to_string();
 		let song = songs.entry(song_id.clone()).or_insert(Song {
 			id: song_id,
 			segments: HashMap::<String, SongSegment>::new(),
@@ -114,10 +93,10 @@ pub fn initialize_songs(paths: &[String]) -> HashMap<String, Song> {
 		if !song.has_end && song_segment_id == "end"{
 			song.has_end = true;
 		}
-		if !song.has_multiple_loops && song_segment_id != "loop" && REGEX_IS_LOOP.is_match(song_segment_id.as_str()) {
+		if !song.has_multiple_loops && song_segment_id != "loop" && REGEX_IS_LOOP.is_match(&song_segment_id) {
 			song.has_multiple_loops = true;
 		}
-		if !song.has_dedicated_transitions && REGEX_IS_DEDICATED_TRANSITION.is_match(song_segment_id.as_str()) {
+		if !song.has_dedicated_transitions && REGEX_IS_DEDICATED_TRANSITION.is_match(&song_segment_id) {
 			song.has_dedicated_transitions = true;
 		}
 		song.segments.entry(song_segment_id.clone()).or_insert(SongSegment {
@@ -136,7 +115,7 @@ pub fn initialize_transitions(songs: &mut HashMap<String, Song>) {
 		for song_segment in song.segments.values_mut() {
 			if REGEX_IS_DEDICATED_TRANSITION.is_match(&song_segment.id) {
 				let loop_nums = REGEX_IS_DEDICATED_TRANSITION.captures(&song_segment.id).unwrap();
-				let (_, loop_to) = (loop_nums.get(1).unwrap(), loop_nums.get(2).unwrap());
+				let loop_to = loop_nums.get(2).unwrap();
 				song_segment.allowed_transitions.insert(format!("loop{}", loop_to.as_str()));
 
 				// can't do this because double borrow
@@ -173,12 +152,12 @@ pub fn initialize_transitions(songs: &mut HashMap<String, Song>) {
 								"loop".to_string()
 							}
 						);
-					}
+					},
 					"loop" => {
 						if song.has_end {
 							song_segment.allowed_transitions.insert("end".to_string());
 						}
-					}
+					},
 					_ => {}
 				}
 			}
@@ -213,7 +192,7 @@ prop_compose! {
 					id: "loop".to_string(),
 					allowed_transitions: set!()
 				});
-			}
+			},
 			_ => {
 				for i in 0..loop_count {
 					segment_vec.push(SongSegment {
@@ -252,18 +231,18 @@ mod test_song_parsing {
 	#[test]
 	fn test_initialize_songs() {
 		let paths = [
-			"songs/song_1_start.ogg".to_string(),
-			"songs/song_1_loop.ogg".to_string(),
-			"songs/song_1_end.ogg".to_string(),
-			"songs/song_2_start.ogg".to_string(),
-			"songs/song_2_loop0.ogg".to_string(),
-			"songs/song_2_loop1.ogg".to_string(),
-			"songs/song_2_end.ogg".to_string(),
-			"songs/song_3_start.ogg".to_string(),
-			"songs/song_3_loop0.ogg".to_string(),
-			"songs/song_3_loop0-to-1.ogg".to_string(),
-			"songs/song_3_loop1.ogg".to_string(),
-			"songs/song_3_end.ogg".to_string()
+			"songs/song_1_start.ogg",
+			"songs/song_1_loop.ogg",
+			"songs/song_1_end.ogg",
+			"songs/song_2_start.ogg",
+			"songs/song_2_loop0.ogg",
+			"songs/song_2_loop1.ogg",
+			"songs/song_2_end.ogg",
+			"songs/song_3_start.ogg",
+			"songs/song_3_loop0.ogg",
+			"songs/song_3_loop0-to-1.ogg",
+			"songs/song_3_loop1.ogg",
+			"songs/song_3_end.ogg"
 		];
 		let songs = initialize_songs(&paths);
 		assert_eq!(songs["1"], Song {
@@ -342,7 +321,7 @@ mod test_song_parsing {
 
 	#[test]
 	fn test_initialize_transitions() {
-		let mut songs = map!{
+		let mut songs = map! {
 			"1".to_string() => Song {
 				id: "1".to_string(),
 				segments: map!(
@@ -435,7 +414,7 @@ mod test_song_parsing {
 		assert_eq!(songs["3"].segments["end"].allowed_transitions, HashSet::new());
 	}
 
-	proptest!{
+	proptest! {
 		#[test]
 		fn prop_multiloop_song_should_not_contain_references_to_loop(song_id in "[a-z0-9]*", loop_count in 2..10) {
 			let mut paths: Vec<String> = vec![format!("songs/song_{}_start.ogg", song_id)];
@@ -475,7 +454,7 @@ mod test_song_parsing {
 mod test_song_planning {
 	use super::*;
 
-	proptest!{
+	proptest! {
 		#[test]
 		fn prop_plan_should_end_with_end(song in song_strategy(12, true)) {
 			let mut rng = rand::thread_rng();
@@ -489,9 +468,26 @@ mod test_song_planning {
 }
 
 fn main() {
-	let args: Vec<String> = env::args().collect();
+	// let args: Vec<String> = env::args().collect();
 
-	let paths = fs::read_dir("./songs").unwrap();
+	// Get executable file location or default to `./` if failed.
+	let mut songs_directory = env::current_exe()
+		.unwrap_or(PathBuf::from("./stream_autodj"));
+
+	// env::current_exe() might return path to symbolic link on some platforms.
+	// try to get real path if it's a symbolic link
+	songs_directory = match songs_directory.read_link() {
+		Ok(path) => path,
+		Err(_) => songs_directory,
+	};
+
+	// Remove executable file name from the path.
+	songs_directory.pop();
+
+	// add 'songs' to the end of the path.
+	songs_directory.push("songs");
+
+	let paths = fs::read_dir(songs_directory).unwrap();
 	let path_strings = paths.map(|p| p.unwrap().path().display().to_string()).collect::<Vec<_>>();
 
 	let mut songs = initialize_songs(&path_strings);
@@ -510,7 +506,7 @@ fn main() {
 		let plan = current_song.make_plan(&mut rng);
 		// println!("{:#?}", plan);
 
-		for segment in plan.clone() {
+		for segment in &plan {
 			let source = current_song.read_segment(&segment.id).buffered();
 			if REGEX_IS_LOOP.is_match(&segment.id) && !REGEX_IS_DEDICATED_TRANSITION.is_match(&segment.id) {
 				let repeat_counts = rng.gen_range(3, 12);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ mod macros;
 use std::fs::File;
 use std::io::BufReader;
 use std::collections::{HashSet, HashMap};
-use std::{env, fs};
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::path::Path;
 use rodio::Sink;
 use rodio::decoder::Decoder;
 use rodio::{source::Zero, Source};
@@ -470,24 +470,7 @@ mod test_song_planning {
 fn main() {
 	// let args: Vec<String> = env::args().collect();
 
-	// Get executable file location or default to `./` if failed.
-	let mut songs_directory = env::current_exe()
-		.unwrap_or(PathBuf::from("./stream_autodj"));
-
-	// env::current_exe() might return path to symbolic link on some platforms.
-	// try to get real path if it's a symbolic link
-	songs_directory = match songs_directory.read_link() {
-		Ok(path) => path,
-		Err(_) => songs_directory,
-	};
-
-	// Remove executable file name from the path.
-	songs_directory.pop();
-
-	// add 'songs' to the end of the path.
-	songs_directory.push("songs");
-
-	let paths = fs::read_dir(songs_directory).unwrap();
+	let paths = fs::read_dir("./songs").unwrap();
 	let path_strings = paths.map(|p| p.unwrap().path().display().to_string()).collect::<Vec<_>>();
 
 	let mut songs = initialize_songs(&path_strings);


### PR DESCRIPTION
- Updated Cargo.lock (just ran `cargo update`)
- Moved macros to other file, added empty branches to make warnings disappear.
    Macros are copy-paste in Rust, so I changed `HashSet::new();` to `:std::collections::HashSet::new();` because it won't work if HashSet is not imported in the file where macro is used.
- Changed  `fn initialize_songs(paths: &[String])` to `fn initialize_songs<P: AsRef<Path>>(paths: &[P])`
    This essentially means that `initialize_songs` accepts anything that can be converted into `Path` by using `as_ref` method. Biggest benefit is that you can pass both `String` and `&str`. `<P: AsRef<Path>>(paths: &[P])` means that you need to pass something that implements `AsRef<Path>` [trait](https://doc.rust-lang.org/stable/std/convert/trait.AsRef.html). Hopefully it's not too confusing. Doing `fn initialize_songs(paths: &[impl AsRef<Path>]` instead also works.
- `path.split('/').rev().next().unwrap().to_string();` might not work on OSes which use `\` as separator, so I replaced it with `path.file_name()` which is cleaner anyway.
- `let (_, loop_to) = (loop_nums.get(1).unwrap(), loop_nums.get(2).unwrap());` -> `let loop_to = loop_nums.get(2).unwrap();`

And a few debatable changes:
- I replaced `regex = "1.3.9"` and `lazy_static = "1.4.0"` in Cargo.toml to `regex = "1"`, `lazy_static = "1"`.
    This lets Cargo to use latest version in `1.y.z` pattern. If library authors follow semver, there should be no breaking changes in `1.y.z` (and Cargo.lock helps here anyway). This is debatable because you might not want that.
- ~~In `main()` I replaced `fs::read_dir("./songs").unwrap();` with more complex code. The problem with the old one was that it tries to read songs from current working directory in your terminal, not from the directory where the executable is. This is debatable because you would need to move your `songs` directory into `target/debug` or `target/release` directory for it to work.~~ Reverted now.