### PR TITLE
Add repeating source with count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod macros;
+mod repeating_source;
 
 use std::fs::File;
 use std::io::BufReader;
@@ -533,9 +534,7 @@ fn main() {
 			let source = current_song.read_segment(&segment.id).buffered();
 			if REGEX_IS_LOOP.is_match(&segment.id) && !REGEX_IS_DEDICATED_TRANSITION.is_match(&segment.id) {
 				let repeat_counts = rng.gen_range(3, 12);
-				for _ in 0..repeat_counts {
-					sink.append(source.clone());
-				}
+				sink.append(repeating_source::repeat_with_count(source, repeat_counts));
 			}
 			else {
 				sink.append(source);

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,7 +531,7 @@ fn main() {
 		// println!("{:#?}", plan);
 
 		for segment in &plan {
-			let source = current_song.read_segment(&segment.id).buffered();
+			let source = current_song.read_segment(&segment.id);
 			if REGEX_IS_LOOP.is_match(&segment.id) && !REGEX_IS_DEDICATED_TRANSITION.is_match(&segment.id) {
 				let repeat_counts = rng.gen_range(3, 12);
 				sink.append(repeating_source::repeat_with_count(source, repeat_counts));

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -6,7 +6,7 @@ use rodio::Source;
 
 
 /// Internal function that builds a `RepeatCount` object.
-pub fn repeat_with_count<I>(input: I,count:i32) -> RepeatCount<I>
+pub fn repeat_with_count<I>(input: I,count: i32) -> RepeatCount<I>
 where
 	I: Source,
 	I::Item: Sample,
@@ -16,7 +16,7 @@ where
 		inner: input.clone(),
 		next: input,
 		count: count,
-		count_remaining:count
+		count_remaining: count
 	}
 }
 
@@ -40,7 +40,7 @@ where
 	type Item = <I as Iterator>::Item;
 
 	#[inline]
-	fn next(&mut self) -> Option<<I as Iterator>::Item> {
+	fn next(&mut self) -> Option<Self::Item> {
 		if let Some(value) = self.inner.next() {
 			return Some(value);
 		}

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -43,11 +43,13 @@ where
 	fn next(&mut self) -> Option<<I as Iterator>::Item> {
 		if let Some(value) = self.inner.next() {
 			return Some(value);
-		}else if self.count_remaining > 1{
+		}
+		else if self.count_remaining > 1 {
 			self.count_remaining -= 1;
 			self.inner = self.next.clone();
 			self.inner.next()
-		}else{
+		}
+		else {
 			None
 		}
 	}

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -90,7 +90,10 @@ where
 
 	#[inline]
 	fn total_duration(&self) -> Option<Duration> {
-		self.inner.total_duration()
+		match self.inner.total_duration() {
+			Some(dur) => {Some(dur.mul_f32(self.count as f32))}
+			None => {None}
+		}
 	}
 }
 

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -8,104 +8,104 @@ use rodio::Source;
 /// Internal function that builds a `RepeatCount` object.
 pub fn repeat_with_count<I>(input: I,count:i32) -> RepeatCount<I>
 where
-    I: Source,
-    I::Item: Sample,
+	I: Source,
+	I::Item: Sample,
 {
-    let input = input.buffered();
-    RepeatCount {
-        inner: input.clone(),
-        next: input,
-        count: count,
-        count_remaining:count
-    }
+	let input = input.buffered();
+	RepeatCount {
+		inner: input.clone(),
+		next: input,
+		count: count,
+		count_remaining:count
+	}
 }
 
 /// A source that repeats the given source.
 pub struct RepeatCount<I>
 where
-    I: Source,
-    I::Item: Sample,
+	I: Source,
+	I::Item: Sample,
 {
-    inner: Buffered<I>,
-    next: Buffered<I>,
-    count: i32,
-    count_remaining: i32
+	inner: Buffered<I>,
+	next: Buffered<I>,
+	count: i32,
+	count_remaining: i32
 }
 
 impl<I> Iterator for RepeatCount<I>
 where
-    I: Source,
-    I::Item: Sample,
+	I: Source,
+	I::Item: Sample,
 {
-    type Item = <I as Iterator>::Item;
+	type Item = <I as Iterator>::Item;
 
-    #[inline]
-    fn next(&mut self) -> Option<<I as Iterator>::Item> {
-        if let Some(value) = self.inner.next() {
-            return Some(value);
-        }else if self.count_remaining > 1{
-            self.count_remaining -= 1;
-            self.inner = self.next.clone();
-            self.inner.next()
-        }else{
-            None
-        }
-    }
+	#[inline]
+	fn next(&mut self) -> Option<<I as Iterator>::Item> {
+		if let Some(value) = self.inner.next() {
+			return Some(value);
+		}else if self.count_remaining > 1{
+			self.count_remaining -= 1;
+			self.inner = self.next.clone();
+			self.inner.next()
+		}else{
+			None
+		}
+	}
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // infinite
-        (0, None)
-    }
+	#[inline]
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		// infinite
+		(0, None)
+	}
 }
 
 impl<I> Source for RepeatCount<I>
 where
-    I: Iterator + Source,
-    I::Item: Sample,
+	I: Iterator + Source,
+	I::Item: Sample,
 {
-    #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        match self.inner.current_frame_len() {
-            Some(0) => self.next.current_frame_len(),
-            a => a,
-        }
-    }
+	#[inline]
+	fn current_frame_len(&self) -> Option<usize> {
+		match self.inner.current_frame_len() {
+			Some(0) => self.next.current_frame_len(),
+			a => a,
+		}
+	}
 
-    #[inline]
-    fn channels(&self) -> u16 {
-        match self.inner.current_frame_len() {
-            Some(0) => self.next.channels(),
-            _ => self.inner.channels(),
-        }
-    }
+	#[inline]
+	fn channels(&self) -> u16 {
+		match self.inner.current_frame_len() {
+			Some(0) => self.next.channels(),
+			_ => self.inner.channels(),
+		}
+	}
 
-    #[inline]
-    fn sample_rate(&self) -> u32 {
-        match self.inner.current_frame_len() {
-            Some(0) => self.next.sample_rate(),
-            _ => self.inner.sample_rate(),
-        }
-    }
+	#[inline]
+	fn sample_rate(&self) -> u32 {
+		match self.inner.current_frame_len() {
+			Some(0) => self.next.sample_rate(),
+			_ => self.inner.sample_rate(),
+		}
+	}
 
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        self.inner.total_duration()
-    }
+	#[inline]
+	fn total_duration(&self) -> Option<Duration> {
+		self.inner.total_duration()
+	}
 }
 
 impl<I> Clone for RepeatCount<I>
 where
-    I: Source,
-    I::Item: Sample,
+	I: Source,
+	I::Item: Sample,
 {
-    #[inline]
-    fn clone(&self) -> RepeatCount<I> {
-        RepeatCount {
-            inner: self.inner.clone(),
-            next: self.next.clone(),
-            count: self.count,
-            count_remaining: self.count_remaining
-        }
-    }
+	#[inline]
+	fn clone(&self) -> RepeatCount<I> {
+		RepeatCount {
+			inner: self.inner.clone(),
+			next: self.next.clone(),
+			count: self.count,
+			count_remaining: self.count_remaining
+		}
+	}
 }

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -1,0 +1,111 @@
+use std::time::Duration;
+
+use rodio::source::Buffered;
+use rodio::Sample;
+use rodio::Source;
+
+
+/// Internal function that builds a `RepeatCount` object.
+pub fn repeat_with_count<I>(input: I,count:i32) -> RepeatCount<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    let input = input.buffered();
+    RepeatCount {
+        inner: input.clone(),
+        next: input,
+        count: count,
+        count_remaining:count
+    }
+}
+
+/// A source that repeats the given source.
+pub struct RepeatCount<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    inner: Buffered<I>,
+    next: Buffered<I>,
+    count: i32,
+    count_remaining: i32
+}
+
+impl<I> Iterator for RepeatCount<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    type Item = <I as Iterator>::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<<I as Iterator>::Item> {
+        if let Some(value) = self.inner.next() {
+            return Some(value);
+        }else if self.count_remaining > 1{
+            self.count_remaining -= 1;
+            self.inner = self.next.clone();
+            self.inner.next()
+        }else{
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // infinite
+        (0, None)
+    }
+}
+
+impl<I> Source for RepeatCount<I>
+where
+    I: Iterator + Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn current_frame_len(&self) -> Option<usize> {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.current_frame_len(),
+            a => a,
+        }
+    }
+
+    #[inline]
+    fn channels(&self) -> u16 {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.channels(),
+            _ => self.inner.channels(),
+        }
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u32 {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.sample_rate(),
+            _ => self.inner.sample_rate(),
+        }
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.inner.total_duration()
+    }
+}
+
+impl<I> Clone for RepeatCount<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn clone(&self) -> RepeatCount<I> {
+        RepeatCount {
+            inner: self.inner.clone(),
+            next: self.next.clone(),
+            count: self.count,
+            count_remaining: self.count_remaining
+        }
+    }
+}


### PR DESCRIPTION
This should allow for decreased memory usage, as we loop over the same memory rather than appending it many times. Uses a modified version of the repeating type that loops forever, so I would expect this to be about as efficient as possible without writing unsafe code.

This is opposed to the current system of appending many clones all at once. 

Sadly, given the way that the repeat source implements its repeating, it doesn't reduce the number of clone calls, there's simply less owned clones of the source at the same time.