### PR TITLE
Allow trailing comma in macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! map {
 		let temp_map = ::std::collections::HashMap::new();
 		temp_map
 	});
-	($($key:expr => $value:expr),+) => ({
+	($($key:expr => $value:expr),+ $(,)?) => ({
 		let mut temp_map = ::std::collections::HashMap::new();
 		$(
 			temp_map.insert($key, $value);
@@ -19,7 +19,7 @@ macro_rules! set {
 		let temp_set = ::std::collections::HashSet::new();
 		temp_set
 	});
-	($($x:expr),+) => ({ // Match one or more comma delimited items
+	($($x:expr),+ $(,)?) => ({ // Match one or more comma delimited items
 		let mut temp_set = ::std::collections::HashSet::new();  // Create a mutable HashSet
 		$(
 			temp_set.insert($x); // Insert each item matched into the HashSet


### PR DESCRIPTION
Currently using those macros with trailing macros doesn't compile with this error: ([link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=60da9d1e5bf1b65b9209b136c5f4320f))
```rust
error: unexpected end of macro invocation
  --> src/main.rs:22:24
   |
4  | macro_rules! map {
   | ---------------- when calling this macro
...
22 |         24 => "Cooler",
   |                        ^ missing tokens in macro arguments

error: aborting due to previous error
```
Fixed by adding `$(,)?`.