### PR TITLE
Change Song::read_segment to read from songs_dir directory argument.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,9 +546,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "239f255b9e3429350f188c27b807fc9920a15eb9145230ff1a7d054c08fec319"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2.33"
 regex = "1"
 lazy_static = "1"
 rodio = "0.11.0"
 rand = "0.7.3"
 proptest = "0.10.0"
-clap = "2.33.1"
 
 [profile.release]
 lto = true

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -15,7 +15,7 @@ where
 	RepeatCount {
 		inner: input.clone(),
 		next: input,
-		count: count,
+		count,
 		count_remaining: count - 1 // Because assigning inner consumes one of the repeats.
 	}
 }

--- a/src/repeating_source.rs
+++ b/src/repeating_source.rs
@@ -16,7 +16,7 @@ where
 		inner: input.clone(),
 		next: input,
 		count: count,
-		count_remaining: count - 1 // because assigning inner consumes one of the repeats.
+		count_remaining: count - 1 // Because assigning inner consumes one of the repeats.
 	}
 }
 
@@ -42,7 +42,7 @@ where
 	#[inline]
 	fn next(&mut self) -> Option<Self::Item> {
 		if let Some(value) = self.inner.next() {
-			return Some(value);
+			Some(value)
 		}
 		else if self.count_remaining > 1 {
 			self.count_remaining -= 1;
@@ -56,7 +56,7 @@ where
 
 	#[inline]
 	fn size_hint(&self) -> (usize, Option<usize>) {
-		// infinite
+		// Infinite.
 		(0, None)
 	}
 }


### PR DESCRIPTION
`extern crate` is not needed in Rust 2018 edition